### PR TITLE
feat: add automatic token refresh

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import { deviceAuthorizationClient } from "better-auth/plugins";
 import { getStoredToken } from "../token";
 import { isDevelopment } from "../utils";
 
-const SERVER_URL = isDevelopment()
+export const SERVER_URL = isDevelopment()
   ? "http://localhost:3001"
   : "https://www.platform.mixedbread.com";
 
@@ -37,6 +37,7 @@ export async function getJWTToken(): Promise<string> {
       Authorization: `Bearer ${token.access_token}`,
     },
   });
+
   if (!response.ok) {
     throw new Error(
       "Failed to get JWT token. You token might have expired. Please run 'mgrep login' to authenticate.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Automatically refreshes expiring device tokens (within 3 days) and exposes `SERVER_URL` for reuse.
> 
> - **Token management (`src/token.ts`)**:
>   - Adds automatic refresh flow when stored token is expiring within 3 days via `POST /api/refresh-device-token`.
>   - Persists refreshed token using existing `storeToken`; returns updated token with new `created_at`.
> - **Auth client (`src/lib/auth.ts`)**:
>   - Exposes `SERVER_URL` for use in token refresh logic.
>   - Uses `SERVER_URL` for JWT exchange at `GET /api/auth/token`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c59fa8730888358f46eb1099b6f8f10285b1a6f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->