### PR TITLE
chore: make the reranking optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ directory for a pattern.
 | `-c`, `--content` | Show content of the results |
 | `-a`, `--answer` | Generate an answer to the question based on the results |
 | `-s`, `--sync` | Sync the local files to the store before searching |
+| `-d`, `--dry-run` | Dry run the search process (no actual file syncing) |
+| `--no-rerank` | Disable reranking of search results |
+
+All search options can also be configured via environment variables (see
+[Environment Variables](#environment-variables) section below).
 
 **Examples:**
 ```bash
@@ -152,7 +157,9 @@ mgrep watch  # index the current repository and keep the Mixedbread store in syn
 ## Mixedbread under the hood
 
 - Every file is pushed into a Mixedbread Store using the same SDK your apps get.
-- Searches request top-k matches with Mixedbread reranking enabled for tighter relevance.
+- Searches request top-k matches with Mixedbread reranking enabled by default
+  for tighter relevance (can be disabled with `--no-rerank` or
+  `MGREP_RERANK=0`).
 - Results include relative paths plus contextual hints (line ranges for text, page numbers for PDFs, etc.) for a skim-friendly experience.
 - Because stores are cloud-backed, agents and teammates can query the same corpus without re-uploading.
 
@@ -163,9 +170,48 @@ mgrep watch  # index the current repository and keep the Mixedbread store in syn
 - `watch` reports progress (`processed / uploaded`) as it scans; leave it running in a terminal tab to keep your store fresh.
 - `search` accepts most `grep`-style switches, and politely ignores anything it cannot support, so existing muscle memory still works.
 
-**Environment Variables:**
+## Environment Variables
+
+All search options can be configured via environment variables, which is
+especially useful for CI/CD pipelines or when you want to set defaults for all
+searches.
+
+### Authentication & Store
+
 - `MXBAI_API_KEY`: Set this to authenticate without browser login (ideal for CI/CD)
 - `MXBAI_STORE`: Override the default store name (default: `mgrep`)
+
+### Search Options
+
+- `MGREP_MAX_COUNT`: Maximum number of results to return (default: `10`)
+- `MGREP_CONTENT`: Show content of the results (set to `1` or `true` to enable)
+- `MGREP_ANSWER`: Generate an answer based on the results (set to `1` or `true` to enable)
+- `MGREP_SYNC`: Sync files before searching (set to `1` or `true` to enable)
+- `MGREP_DRY_RUN`: Enable dry run mode (set to `1` or `true` to enable)
+- `MGREP_RERANK`: Enable reranking of search results (set to `0` or `false` to disable, default: enabled)
+
+**Examples:**
+```bash
+# Set default max results to 25
+export MGREP_MAX_COUNT=25
+mgrep "search query"
+
+# Always show content in results
+export MGREP_CONTENT=1
+mgrep "search query"
+
+# Disable reranking globally
+export MGREP_RERANK=0
+mgrep "search query"
+
+# Use multiple options together
+export MGREP_MAX_COUNT=20
+export MGREP_CONTENT=1
+export MGREP_ANSWER=1
+mgrep "search query"
+```
+
+Note: Command-line options always override environment variables.
 
 ## Development
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -359,7 +359,7 @@ export class TestStore implements Store {
     _storeId: string,
     query: string,
     top_k?: number,
-    _search_options?: { rerank?: boolean },
+    search_options?: { rerank?: boolean },
     filters?: SearchFilter,
   ): Promise<SearchResponse> {
     const db = await this.load();
@@ -386,7 +386,8 @@ export class TestStore implements Store {
         if (lines[i].toLowerCase().includes(query.toLowerCase())) {
           results.push({
             type: "text",
-            text: lines[i],
+            text:
+              lines[i] + (search_options?.rerank ? "" : " without reranking"),
             score: 1.0,
             metadata: file.metadata,
             chunk_index: results.length - 1,

--- a/test/test.bats
+++ b/test/test.bats
@@ -55,6 +55,7 @@ teardown() {
     assert_success
     assert_output --partial 'test.txt'
     refute_output --partial 'test-2.txt'
+    refute_output --partial 'without reranking'
 }
 
 @test "Search with answer" {
@@ -208,4 +209,20 @@ teardown() {
     assert_success
     assert_output --partial 'test.txt'
     refute_output --partial 'test.log'
+}
+
+@test "Search with no rerank" {
+    run mgrep search -c --no-rerank test
+
+    assert_success
+    assert_output --partial 'test.txt'
+    assert_output --partial 'without reranking'
+}
+
+@test "Search with no rerank environment variable" {
+    export MGREP_RERANK=0
+    output=$(mgrep search -c test)
+
+    assert_output --partial 'test.txt'
+    assert_output --partial 'without reranking'
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional reranking to search (default on) configurable via `--no-rerank` and `MGREP_RERANK`, plus env-driven defaults for other search flags, with docs and tests updated.
> 
> - **CLI (search command)**
>   - Add `--no-rerank` flag; wire `rerank` through to `store.search`/`store.ask`.
>   - Read defaults from env vars: `MGREP_MAX_COUNT`, `MGREP_CONTENT`, `MGREP_ANSWER`, `MGREP_SYNC`, `MGREP_DRY_RUN`, `MGREP_RERANK`.
>   - `--max-count` now defaults to `MGREP_MAX_COUNT` if set.
> - **Store layer**
>   - `TestStore.search` respects `search_options.rerank` (appends " without reranking" when disabled) and passes through filters/limits.
>   - Parameter naming cleanup in `search` for clarity; Mixedbread client forwards `search_options` unchanged.
> - **Docs**
>   - README: document `--no-rerank`, `--dry-run`, and all searchable env vars; note reranking enabled by default and how to disable.
> - **Tests**
>   - Add bats tests for `--no-rerank` and `MGREP_RERANK=0`; ensure default keeps reranking enabled (no "without reranking").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff1dbd5821f99c0ae4d5c9d543a80baf20ce31b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->