### PR TITLE
chore: add a uninstall claude code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { login } from "./commands/login";
 import { logout } from "./commands/logout";
 import { search } from "./commands/search";
 import { watch } from "./commands/watch";
-import { installClaudeCode } from "./install/claude-code";
+import { installClaudeCode, uninstallClaudeCode } from "./install/claude-code";
 import { setupLogger } from "./lib/logger";
 
 setupLogger();
@@ -28,6 +28,7 @@ program
 program.addCommand(search, { isDefault: true });
 program.addCommand(watch);
 program.addCommand(installClaudeCode);
+program.addCommand(uninstallClaudeCode);
 program.addCommand(login);
 program.addCommand(logout);
 

--- a/src/install/claude-code.ts
+++ b/src/install/claude-code.ts
@@ -16,11 +16,11 @@ function installPlugin() {
         console.error(
           `Do you have claude-code version 2.0.36 or higher installed?`,
         );
-        process.exit(1);
+      } else {
+        console.log(
+          "Successfully added the mixedbread-ai/mgrep plugin to the marketplace",
+        );
       }
-      console.log(
-        "Successfully added the mixedbread-ai/mgrep plugin to the marketplace",
-      );
       exec(
         "claude plugin install mgrep",
         { shell, env: process.env },
@@ -39,9 +39,48 @@ function installPlugin() {
   );
 }
 
+function uninstallPlugin() {
+  exec(
+    "claude plugin uninstall mgrep",
+    { shell, env: process.env },
+    (error) => {
+      if (error) {
+        console.error(`Error uninstalling plugin: ${error}`);
+        console.error(
+          `Do you have claude-code version 2.0.36 or higher installed?`,
+        );
+      } else {
+        console.log("Successfully uninstalled the mgrep plugin");
+      }
+      exec(
+        "claude plugin marketplace remove mixedbread-ai/mgrep",
+        { shell, env: process.env },
+        (error) => {
+          if (error) {
+            console.error(`Error removing plugin from marketplace: ${error}`);
+            console.error(
+              `Do you have claude-code version 2.0.36 or higher installed?`,
+            );
+            process.exit(1);
+          }
+          console.log(
+            "Successfully removed the mixedbread-ai/mgrep plugin from the marketplace",
+          );
+        },
+      );
+    },
+  );
+}
+
 export const installClaudeCode = new Command("install-claude-code")
   .description("Install the Claude Code plugin")
   .action(async () => {
     await ensureAuthenticated();
     await installPlugin();
+  });
+
+export const uninstallClaudeCode = new Command("uninstall-claude-code")
+  .description("Uninstall the Claude Code plugin")
+  .action(async () => {
+    await uninstallPlugin();
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `uninstall-claude-code` command with uninstall flow and tweaks install logging/error handling.
> 
> - **CLI**:
>   - Add `uninstall-claude-code` command in `src/install/claude-code.ts` and register it in `src/index.ts`.
> - **Claude Code plugin management**:
>   - Implement `uninstallPlugin()` to run `claude plugin uninstall mgrep` and remove `mixedbread-ai/mgrep` from the marketplace with success/error logs.
>   - Adjust `installPlugin()` to log marketplace add success and avoid immediate exit on initial add failure (still exits on install failure).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f2e84da53e6e061d721b67309d8e509ccd238a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->