### PR TITLE
fix(login): improve fetch failed error with MGREP_ENV override

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,8 +3,9 @@ import chalk from "chalk";
 import { Command } from "commander";
 import open from "open";
 import yoctoSpinner from "yocto-spinner";
-import { authClient } from "../lib/auth";
+import { authClient, SERVER_URL } from "../lib/auth";
 import { getStoredToken, pollForToken, storeToken } from "../token";
+import { isConnectionError, printConnectionErrorHint } from "../utils";
 
 const CLIENT_ID = "mgrep";
 
@@ -112,7 +113,11 @@ export async function loginAction() {
     }
   } catch (err) {
     spinner.stop();
-    console.error(`${err instanceof Error ? err.message : "Unknown error"}`);
+    const errorMessage = err instanceof Error ? err.message : "Unknown error";
+    console.error(errorMessage);
+    if (isConnectionError(err)) {
+      printConnectionErrorHint(SERVER_URL);
+    }
     process.exit(1);
   }
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,7 @@
 import { join, normalize } from "node:path";
 import type { Command } from "commander";
 import { Command as CommanderCommand } from "commander";
-import { createFileSystem, createStore } from "../lib/context";
+import { BASE_URL, createFileSystem, createStore } from "../lib/context";
 import type {
   AskResponse,
   ChunkType,
@@ -12,7 +12,11 @@ import {
   createIndexingSpinner,
   formatDryRunSummary,
 } from "../lib/sync-helpers";
-import { initialSync } from "../utils";
+import {
+  initialSync,
+  isConnectionError,
+  printConnectionErrorHint,
+} from "../utils";
 
 function extractSources(response: AskResponse): { [key: number]: ChunkType } {
   const sources: { [key: number]: ChunkType } = {};
@@ -248,6 +252,9 @@ export const search: Command = new CommanderCommand("search")
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
       console.error("Failed to search:", message);
+      if (isConnectionError(error)) {
+        printConnectionErrorHint(BASE_URL);
+      }
       process.exitCode = 1;
     }
   });

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -9,7 +9,7 @@ import {
 import { type Git, NodeGit } from "./git";
 import { MixedbreadStore, type Store, TestStore } from "./store";
 
-const BASE_URL = isDevelopment()
+export const BASE_URL = isDevelopment()
   ? "http://localhost:8000"
   : "https://api.mixedbread.com";
 


### PR DESCRIPTION
Add MGREP_ENV environment variable to override isDevelopment detection:
- MGREP_ENV=production: force production mode (platform.mixedbread.com)
- MGREP_ENV=development: force development mode (localhost)

When fetch fails during login, now shows:
- isDevelopment status
- Server URL being used
- Hint to set MGREP_ENV=production if in dev mode

Closes #35

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add MGREP_ENV to control dev/prod endpoints and show connection error hints (with server URL) in login/search, exporting BASE_URL for reuse.
> 
> - **CLI environment & error handling**:
>   - **`src/utils.ts`**: Add `MGREP_ENV` override to `isDevelopment()`; introduce `isConnectionError()` and `printConnectionErrorHint()` to surface dev/prod mode and server URL on connection failures; keep hash helpers.
> - **Login**:
>   - **`src/commands/login.ts`**: On errors, detect connection issues and print hint using `SERVER_URL`; minor error message cleanup.
> - **Search**:
>   - **`src/commands/search.ts`**: On connection errors, print hint using `BASE_URL`; import `BASE_URL` from context.
> - **Context**:
>   - **`src/lib/context.ts`**: Export `BASE_URL` for shared use across commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b49147fa2d81c75ec085875de3e79b8e1136de1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->