### PR TITLE
chore: don't use the local api for development by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ pnpm format       # biome formatting + linting
 
 - The executable lives at `dist/index.js` (built from TypeScript via `tsc`).
 - Husky is wired via `pnpx husky init` (run `npx husky init` once after cloning).
-- Tests are not wired up yet—`pnpm typecheck` is your best friend before publishing.
+- Tests are not wired up yet—`pnpm typecheck` is your best friend before
+  publishing.
+- To connect to a local Mixedbread api set the `export NODE_ENV=development`.
 
 ### Testing
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,18 +29,11 @@ export function computeFileHash(
 }
 
 export function isDevelopment(): boolean {
-  // Check if running from node_modules (published package)
-  if (__dirname.includes("node_modules")) {
-    return false;
-  }
-
-  // Check if NODE_ENV is set to development
   if (process.env.NODE_ENV === "development" || isTest) {
     return true;
   }
 
-  // Default to local if we can't determine
-  return true;
+  return false;
 }
 
 export async function listStoreFileHashes(


### PR DESCRIPTION
Not all developers have access to the api source code and can not run
it locally. Let's use the prod api as a default so that these
developers can still test it locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens dev-mode detection to require NODE_ENV=development (no longer defaults to local) and updates docs with the new instruction.
> 
> - **Runtime behavior**:
>   - `src/utils.ts`: `isDevelopment()` now returns true only when `process.env.NODE_ENV === "development"` or tests are running; removed node_modules check and default-to-true behavior (defaults to false otherwise).
> - **Docs**:
>   - `README.md` (Development): clarifies that setting `NODE_ENV=development` connects to a local Mixedbread API; minor formatting for test/typecheck note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f47edb6b1d55eced015e8cd0d03a0ffa6249e2f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->