### PR TITLE
chore: ignore can't write log error

### DIFF
--- a/src/install/codex.ts
+++ b/src/install/codex.ts
@@ -56,6 +56,7 @@ async function installPlugin() {
       shell,
       env: process.env,
     });
+    console.log("Successfully installed the mgrep background sync");
 
     const destPath = path.join(os.homedir(), ".codex", "AGENTS.md");
     fs.mkdirSync(path.dirname(destPath), { recursive: true });


### PR DESCRIPTION
We can't persist the logs in sandboxed environments.
Let's ignore them for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only enable rotating file logs if the log directory is writable (otherwise run silently) and log a success message after installing Codex mgrep.
> 
> - **Logging**
>   - Conditionally configure `DailyRotateFile` in `src/lib/logger.ts` only if `LOG_DIR` is writable via new `canWriteToDir()`.
>   - Set `winston` logger `silent` when no transports are available; use dynamic `transports` array.
> - **Installer**
>   - Add success `console.log` after `codex mcp add mgrep mgrep mcp` in `src/install/codex.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00c68c6f6d0488167b2ea0a70b3834b1682bb0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->