### PR TITLE
chore: refactor the default ignores

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,6 +2,7 @@ import { join, normalize } from "node:path";
 import type { Command } from "commander";
 import { Command as CommanderCommand } from "commander";
 import { createFileSystem, createStore } from "../lib/context";
+import { DEFAULT_IGNORE_PATTERNS } from "../lib/file";
 import type {
   AskResponse,
   ChunkType,
@@ -167,13 +168,7 @@ export const search: Command = new CommanderCommand("search")
 
       if (options.sync) {
         const fileSystem = createFileSystem({
-          ignorePatterns: [
-            "*.lock",
-            "*.bin",
-            "*.ipynb",
-            "*.pyc",
-            "*.safetensors",
-          ],
+          ignorePatterns: [...DEFAULT_IGNORE_PATTERNS],
         });
         const { spinner, onProgress } = createIndexingSpinner(root);
         const result = await initialSync(

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Command } from "commander";
 import { createFileSystem, createStore } from "../lib/context";
+import { DEFAULT_IGNORE_PATTERNS } from "../lib/file";
 import {
   createIndexingSpinner,
   formatDryRunSummary,
@@ -15,7 +16,7 @@ export async function startWatch(options: {
   try {
     const store = await createStore();
     const fileSystem = createFileSystem({
-      ignorePatterns: ["*.lock", "*.bin", "*.ipynb", "*.pyc", "*.safetensors"],
+      ignorePatterns: [...DEFAULT_IGNORE_PATTERNS],
     });
     const watchRoot = process.cwd();
     console.debug("Watching for file changes in", watchRoot);

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -4,6 +4,20 @@ import ignore from "ignore";
 import type { Git } from "./git";
 
 /**
+ * Default glob patterns to ignore during file indexing.
+ * These are not recognized as binary and also can't be uploaded to Mixedbread.
+ */
+export const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
+  "*.lock",
+  "*.bin",
+  "*.ipynb",
+  "*.pyc",
+  "*.safetensors",
+  "*.sqlite",
+  "*.pt",
+];
+
+/**
  * Configuration options for file system operations
  */
 export interface FileSystemOptions {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes and expands default file ignore patterns, and updates search/watch to use them.
> 
> - **Core**:
>   - **`src/lib/file.ts`**: Introduces `DEFAULT_IGNORE_PATTERNS` (e.g., `*.lock`, `*.bin`, `*.ipynb`, `*.pyc`, `*.safetensors`, `*.sqlite`, `*.pt`) for shared indexing ignores.
> - **Commands**:
>   - **`src/commands/search.ts`**: Replaces inline ignore list with `DEFAULT_IGNORE_PATTERNS` during sync.
>   - **`src/commands/watch.ts`**: Replaces inline ignore list with `DEFAULT_IGNORE_PATTERNS` for watcher/indexing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5732f1cbdcbe709dc83a5835e327d54d22fc4e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->