### PR TITLE
Revert "feat: let users choose org in login flow (#52)"

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { Command } from "commander";
 import open from "open";
 import yoctoSpinner from "yocto-spinner";
-import { authClient, SERVER_URL } from "../lib/auth";
+import { authClient } from "../lib/auth";
 import { getStoredToken, pollForToken, storeToken } from "../token";
 
 const CLIENT_ID = "mgrep";
@@ -44,16 +44,23 @@ export async function loginAction() {
       process.exit(1);
     }
 
-    const { device_code, user_code, interval = 5, expires_in } = data;
-
-    const urlToOpen = `${SERVER_URL}/select-organization?user_code=${user_code}`;
+    const {
+      device_code,
+      user_code,
+      verification_uri,
+      verification_uri_complete,
+      interval = 5,
+      expires_in,
+    } = data;
 
     // Display authorization instructions
     console.log("");
     console.log(chalk.cyan("📱 Device Authorization Required"));
     console.log("");
     console.log("Login to your Mixedbread platform account, then:");
-    console.log(`Please visit: ${chalk.underline.blue(urlToOpen)}`);
+    console.log(
+      `Please visit: ${chalk.underline.blue(`${verification_uri}?user_code=${user_code}`)}`,
+    );
     console.log(`Enter code: ${chalk.bold.green(user_code)}`);
     console.log("");
 
@@ -64,6 +71,7 @@ export async function loginAction() {
     });
 
     if (!isCancel(shouldOpen) && shouldOpen) {
+      const urlToOpen = verification_uri_complete || verification_uri;
       await open(urlToOpen);
     }
 


### PR DESCRIPTION
This reverts commit d1b07cfcd4719f7abc13668c8e8538bf50f3cd48.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the login device flow to use `verification_uri`/`verification_uri_complete` from the auth response instead of a custom org selection URL.
> 
> - **CLI Login Flow (`src/commands/login.ts`)**:
>   - Use `verification_uri` and `verification_uri_complete` from `authClient.device.code` response for user verification.
>   - Browser open prefers `verification_uri_complete`, falls back to `verification_uri`.
>   - Console instructions link updated to `verification_uri?user_code=...` and prominently display `user_code`.
>   - Remove `SERVER_URL` usage and the custom `/select-organization` URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcdf9735e0e4800677c8d5b7dbbd9564490c35e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->