### PR TITLE
chore: bundle the plugin definition as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "chmod +x dist/index.js",
+    "postbuild": "chmod +x dist/index.js && cp -r plugins dist/",
     "dev": "npx tsc && node dist/index.js",
     "test": "bats test/test.bats",
     "format": "biome check --write .",

--- a/src/install/droid.ts
+++ b/src/install/droid.ts
@@ -6,7 +6,7 @@ import { ensureAuthenticated } from "../lib/utils";
 
 const PLUGIN_ROOT =
   process.env.DROID_PLUGIN_ROOT ||
-  path.resolve(__dirname, "../../plugins/mgrep");
+  path.resolve(__dirname, "../../dist/plugins/mgrep");
 const PLUGIN_HOOKS_DIR = path.join(PLUGIN_ROOT, "hooks");
 const PLUGIN_SKILL_PATH = path.join(PLUGIN_ROOT, "skills", "mgrep", "SKILL.md");
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bundles plugin assets into `dist` and updates the installer to load them from the built output.
> 
> - **Build**:
>   - Update `postbuild` to copy `plugins` into `dist` (`cp -r plugins dist/`).
> - **Installer**:
>   - Point `PLUGIN_ROOT` from `../../plugins/mgrep` to `../../dist/plugins/mgrep` so hooks/skill are read from bundled assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98f33dc31370a734a14911235b854a156ab578af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->