### PR TITLE
fix: improve error handling for quota limits and upload failures

### DIFF
--- a/src/lib/sync-helpers.ts
+++ b/src/lib/sync-helpers.ts
@@ -10,14 +10,17 @@ export interface InitialSyncProgress {
   processed: number;
   uploaded: number;
   deleted: number;
+  errors: number;
   total: number;
   filePath?: string;
+  lastError?: string;
 }
 
 export interface InitialSyncResult {
   processed: number;
   uploaded: number;
   deleted: number;
+  errors: number;
   total: number;
 }
 
@@ -55,7 +58,8 @@ export function createIndexingSpinner(
       const rel = formatRelativePath(root, info.filePath);
       const suffix = rel ? ` ${rel}` : "";
       const deletedInfo = info.deleted > 0 ? ` • deleted ${info.deleted}` : "";
-      spinner.text = `Indexing files (${info.processed}/${info.total}) • uploaded ${info.uploaded}${deletedInfo}${suffix}`;
+      const errorsInfo = info.errors > 0 ? ` • errors ${info.errors}` : "";
+      spinner.text = `Indexing files (${info.processed}/${info.total}) • uploaded ${info.uploaded}${deletedInfo}${errorsInfo}${suffix}`;
     },
   };
 }


### PR DESCRIPTION
## Summary

- Detect and handle free tier quota limits gracefully
- Stop processing immediately when quota is exceeded (instead of continuing to spam errors)
- Show clean, actionable error message with upgrade URL

## Problem

When users hit the free tier quota limit, mgrep would:
1. Print hundreds of identical error messages (one per file)
2. Continue trying to upload files even though all would fail
3. Show confusing output that made it hard to understand what went wrong

**Before:**
\`\`\`
Failed to upload /path/to/file1.ts: 403 Free tier can ingest at most 2000000 store tokens per month...
Failed to upload /path/to/file2.ts: 403 Free tier can ingest at most 2000000 store tokens per month...
Failed to upload /path/to/file3.ts: 403 Free tier can ingest at most 2000000 store tokens per month...
... (hundreds more lines)
\`\`\`

**After:**
\`\`\`
Watching for file changes in /path/to/repo
- Indexing files...
✖ Quota exceeded

❌ Free tier quota exceeded. You've reached the monthly limit of 2,000,000 store tokens.
   Upgrade your plan at https://platform.mixedbread.com to continue syncing.
\`\`\`

## Changes

1. **QuotaExceededError class** - New error type to identify quota/rate limit issues
2. **isQuotaError helper** - Detects quota-related error messages
3. **Early termination** - Stops processing remaining files when quota is hit
4. **Error tracking** - Added \`errors\` counter to \`InitialSyncProgress\` and \`InitialSyncResult\`
5. **Clean output** - Single informative message with upgrade URL instead of spam

## Testing

Tested locally with a free tier account that had exceeded its quota. The new behavior correctly:
- Detects the quota error on first failed upload
- Stops processing immediately
- Shows the clean error message
- Exits with code 1

Closes #67

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects quota/rate-limit errors, halts syncing early, surfaces a single clear message, and tracks error counts during initial sync.
> 
> - **Error Handling & Control Flow**:
>   - Introduce `QuotaExceededError` and `isQuotaError` to detect quota/rate-limit failures.
>   - `uploadFile` throws `QuotaExceededError` on quota errors (both stream and text fallback paths) to stop processing early.
>   - `initialSync` halts further work on quota hit, propagates the error after cleanup.
> - **Progress & Reporting**:
>   - Extend `InitialSyncProgress`/`InitialSyncResult` with `errors` and optional `lastError`.
>   - Update `createIndexingSpinner` to display `errors` count in progress text.
>   - In `watch.ts`, show warning summary when `errors > 0`; on `QuotaExceededError`, fail spinner with "Quota exceeded" and print upgrade guidance, then exit.
> - **Misc**:
>   - Wire new error handling through `watch.ts` initial sync flow and maintain dry-run summary output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f50c2360767cb50dd82405213b72fd4db3095b75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->