### PR TITLE
feat: add path prefix filtering to listFiles method

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -62,12 +62,21 @@ export function isDevelopment(): boolean {
   return false;
 }
 
+/**
+ * Lists file hashes from the store, optionally filtered by path prefix.
+ *
+ * @param store - The store instance
+ * @param storeId - The ID of the store
+ * @param pathPrefix - Optional path prefix to filter files (only files starting with this path are returned)
+ * @returns A map of external IDs to their hashes
+ */
 export async function listStoreFileHashes(
   store: Store,
   storeId: string,
+  pathPrefix?: string,
 ): Promise<Map<string, string | undefined>> {
   const byExternalId = new Map<string, string | undefined>();
-  for await (const file of store.listFiles(storeId)) {
+  for await (const file of store.listFiles(storeId, { pathPrefix })) {
     const externalId = file.external_id ?? undefined;
     if (!externalId) continue;
     const metadata = file.metadata;
@@ -179,7 +188,7 @@ export async function initialSync(
   dryRun?: boolean,
   onProgress?: (info: InitialSyncProgress) => void,
 ): Promise<InitialSyncResult> {
-  const storeHashes = await listStoreFileHashes(store, storeId);
+  const storeHashes = await listStoreFileHashes(store, storeId, repoRoot);
   const allFiles = Array.from(fileSystem.getFiles(repoRoot));
   const repoFiles = allFiles.filter(
     (filePath) => !fileSystem.isIgnored(filePath, repoRoot),

--- a/test/test.bats
+++ b/test/test.bats
@@ -298,3 +298,24 @@ teardown() {
     assert_success
     refute_output --partial 'test-2.txt'
 }
+
+@test "Sync from subdirectory only processes files in that subdirectory" {
+    mkdir -p "$BATS_TMPDIR/test-store/projectA"
+    mkdir -p "$BATS_TMPDIR/test-store/projectB"
+    echo "Project A file 1" > "$BATS_TMPDIR/test-store/projectA/a1.txt"
+    echo "Project A file 2" > "$BATS_TMPDIR/test-store/projectA/a2.txt"
+    echo "Project B file 1" > "$BATS_TMPDIR/test-store/projectB/b1.txt"
+
+    run mgrep search --sync test
+    assert_success
+
+    echo "Modified A file 1" > "$BATS_TMPDIR/test-store/projectA/a1.txt"
+
+    cd "$BATS_TMPDIR/test-store/projectA"
+    run mgrep watch --dry-run
+
+    assert_success
+    assert_output --partial 'a1.txt'
+    refute_output --partial 'b1.txt'
+    refute_output --partial 'test.txt'
+}


### PR DESCRIPTION
- Introduced ListFilesOptions interface to support optional path prefix filtering in the listFiles method of the Store interface.
- Updated MixedbreadStore and TestStore implementations to handle the new options.
- Modified listStoreFileHashes function to accept pathPrefix for filtering files.
- Added a test case to verify that only files from a specified subdirectory are processed during sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add pathPrefix filtering to listFiles and use it to scope initial sync/hash listing to subdirectories, with tests validating subdir-only processing.
> 
> - **Store API**:
>   - Add `ListFilesOptions` with `pathPrefix` and update `Store.listFiles(storeId, options)`.
>   - Implement filtering in `MixedbreadStore.listFiles` via `metadata_filter` (`path` `starts_with`) and in `TestStore.listFiles` via in-memory prefix check.
> - **Utils/Sync**:
>   - Update `listStoreFileHashes(store, storeId, pathPrefix)` to pass `pathPrefix` to `store.listFiles`.
>   - Scope `initialSync` by passing `repoRoot` as `pathPrefix` to only consider files within the current subtree.
> - **Tests**:
>   - Add test ensuring syncing from a subdirectory only processes files in that subdirectory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f4ddcdf1763f6508e61ffb1ac94f74860c295f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->