### PR TITLE
chore: add slack badge for support access

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ The tests are written using [bats](https://bats-core.readthedocs.io/en/stable/).
 - **Watcher feels noisy**: set `MXBAI_STORE` or pass `--store` to separate experiments, or pause the watcher and restart after large refactors.
 - **Need a fresh store**: delete it from the Mixedbread dashboard, then run `mgrep watch`. It will auto-create a new one.
 
+## Support
+
+For usage questions, feedback, or other support, please reach out on the [Mixedbread Slack](https://join.slack.com/t/mixedbreadcommunity/shared_invite/zt-3kagj5m36-wwM_hryIFby7B2wlcOaHaQ).
+
 ## License
 
 Apache-2.0. See the [LICENSE](https://opensource.org/licenses/Apache-2.0) file for details.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Slack community badge to the README header and a new Support section linking to Slack.
> 
> - **Documentation**:
>   - Add Slack community badge/link in `README.md` header alongside existing badges.
>   - Introduce **Support** section in `README.md` directing users to the Mixedbread Slack community.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc72db79f9f82c6d97289a3ecb062b82ff1e50ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->