### PR TITLE
feat: add a max file size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ directory for a pattern.
 | `-s`, `--sync` | Sync the local files to the store before searching |
 | `-d`, `--dry-run` | Dry run the search process (no actual file syncing) |
 | `--no-rerank` | Disable reranking of search results |
+| `--max-file-size <bytes>` | Maximum file size in bytes to upload (overrides config) |
 
 All search options can also be configured via environment variables (see
 [Environment Variables](#environment-variables) section below).
@@ -168,9 +169,15 @@ It respects the current `.gitignore`, as well as a `.mgrepignore` file in the
 root of the repository. The `.mgrepignore` file follows the same syntax as the
 [`.gitignore`](https://git-scm.com/docs/gitignore) file.
 
+| Option | Description |
+| --- | --- |
+| `-d`, `--dry-run` | Dry run the watch process (no actual file syncing) |
+| `--max-file-size <bytes>` | Maximum file size in bytes to upload (overrides config) |
+
 **Examples:**
 ```bash
 mgrep watch  # index the current repository and keep the Mixedbread store in sync via file watchers
+mgrep watch --max-file-size 1048576  # limit uploads to files under 1MB
 ```
 
 ## Mixedbread under the hood
@@ -182,7 +189,27 @@ mgrep watch  # index the current repository and keep the Mixedbread store in syn
 - Results include relative paths plus contextual hints (line ranges for text, page numbers for PDFs, etc.) for a skim-friendly experience.
 - Because stores are cloud-backed, agents and teammates can query the same corpus without re-uploading.
 
-## Configuration Tips
+## Configuration
+
+mgrep can be configured via config files, environment variables, or CLI flags.
+
+### Config File
+
+Create a `.mgreprc.yaml` (or `.mgreprc.yml`) in your project root for local configuration, or `~/.config/mgrep/config.yaml` (or `config.yml`) for global configuration.
+
+```yaml
+# Maximum file size in bytes to upload (default: 10MB)
+maxFileSize: 5242880
+```
+
+**Configuration precedence** (highest to lowest):
+1. CLI flags (`--max-file-size`)
+2. Environment variables (`MGREP_MAX_FILE_SIZE`)
+3. Local config file (`.mgreprc.yaml` in project directory)
+4. Global config file (`~/.config/mgrep/config.yaml`)
+5. Default values
+
+### Configuration Tips
 
 - `--store <name>` lets you isolate workspaces (per repo, per team, per experiment). Stores are created on demand if they do not exist yet.
 - Ignore rules come straight from git, so temp files, build outputs, and vendored deps stay out of your embeddings.
@@ -208,6 +235,10 @@ searches.
 - `MGREP_SYNC`: Sync files before searching (set to `1` or `true` to enable)
 - `MGREP_DRY_RUN`: Enable dry run mode (set to `1` or `true` to enable)
 - `MGREP_RERANK`: Enable reranking of search results (set to `0` or `false` to disable, default: enabled)
+
+### Sync Options
+
+- `MGREP_MAX_FILE_SIZE`: Maximum file size in bytes to upload (default: `10485760` / 10MB)
 
 **Examples:**
 ```bash

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "p-limit": "^3.1.0",
     "winston": "^3.18.3",
     "winston-daily-rotate-file": "^5.0.0",
+    "yaml": "^2.8.2",
     "yocto-spinner": "^1.0.0",
     "zod": "^4.1.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       winston-daily-rotate-file:
         specifier: ^5.0.0
         version: 5.0.0(winston@3.18.3)
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
       yocto-spinner:
         specifier: ^1.0.0
         version: 1.0.0
@@ -980,6 +983,11 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1961,6 +1969,8 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
+
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,204 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import YAML from "yaml";
+import { z } from "zod";
+
+const LOCAL_CONFIG_FILES = [".mgreprc.yaml", ".mgreprc.yml"] as const;
+const GLOBAL_CONFIG_DIR = ".config/mgrep";
+const GLOBAL_CONFIG_FILES = ["config.yaml", "config.yml"] as const;
+const ENV_PREFIX = "MGREP_";
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+const ConfigSchema = z.object({
+  maxFileSize: z.number().positive().optional(),
+});
+
+/**
+ * CLI options that can override config
+ */
+export interface CliConfigOptions {
+  maxFileSize?: number;
+}
+
+/**
+ * Mgrep configuration options
+ */
+export interface MgrepConfig {
+  /**
+   * Maximum file size in bytes that is allowed to upload.
+   * Files larger than this will be skipped during sync.
+   * @default 10485760 (10 MB)
+   */
+  maxFileSize: number;
+}
+
+const DEFAULT_CONFIG: MgrepConfig = {
+  maxFileSize: DEFAULT_MAX_FILE_SIZE,
+};
+
+const configCache = new Map<string, MgrepConfig>();
+
+/**
+ * Reads and parses a YAML config file
+ *
+ * @param filePath - The path to the config file
+ * @returns The parsed config object or null if file doesn't exist or is invalid
+ */
+function readYamlConfig(filePath: string): Partial<MgrepConfig> | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const parsed = YAML.parse(content);
+    const validated = ConfigSchema.parse(parsed);
+    return validated;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Warning: Failed to parse config file ${filePath}: ${message}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Finds and reads the first existing config file from a list of candidates
+ *
+ * @param candidates - List of file paths to check
+ * @returns The parsed config or null if none found
+ */
+function findConfig(candidates: string[]): Partial<MgrepConfig> | null {
+  for (const filePath of candidates) {
+    const config = readYamlConfig(filePath);
+    if (config !== null) {
+      return config;
+    }
+  }
+  return null;
+}
+
+function getGlobalConfigPaths(): string[] {
+  const configDir = path.join(os.homedir(), GLOBAL_CONFIG_DIR);
+  return GLOBAL_CONFIG_FILES.map((file) => path.join(configDir, file));
+}
+
+function getLocalConfigPaths(dir: string): string[] {
+  return LOCAL_CONFIG_FILES.map((file) => path.join(dir, file));
+}
+
+/**
+ * Loads configuration from environment variables
+ *
+ * @returns The config values from environment variables
+ */
+function loadEnvConfig(): Partial<MgrepConfig> {
+  const config: Partial<MgrepConfig> = {};
+
+  const maxFileSizeEnv = process.env[`${ENV_PREFIX}MAX_FILE_SIZE`];
+  if (maxFileSizeEnv) {
+    const parsed = Number.parseInt(maxFileSizeEnv, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      config.maxFileSize = parsed;
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Loads mgrep configuration with the following precedence (highest to lowest):
+ * 1. CLI flags (passed as cliOptions)
+ * 2. Environment variables (MGREP_MAX_FILE_SIZE)
+ * 3. Local config file (.mgreprc.yaml or .mgreprc.yml in project directory)
+ * 4. Global config file (~/.config/mgrep/config.yaml or config.yml)
+ * 5. Default values
+ *
+ * @param dir - The directory to load local configuration from
+ * @param cliOptions - CLI options that override all other config sources
+ * @returns The merged configuration
+ */
+export function loadConfig(
+  dir: string,
+  cliOptions: CliConfigOptions = {},
+): MgrepConfig {
+  const absoluteDir = path.resolve(dir);
+  const cacheKey = `${absoluteDir}:${JSON.stringify(cliOptions)}`;
+
+  if (configCache.has(cacheKey)) {
+    return configCache.get(cacheKey) as MgrepConfig;
+  }
+
+  const globalConfig = findConfig(getGlobalConfigPaths());
+  const localConfig = findConfig(getLocalConfigPaths(absoluteDir));
+  const envConfig = loadEnvConfig();
+
+  const config: MgrepConfig = {
+    ...DEFAULT_CONFIG,
+    ...globalConfig,
+    ...localConfig,
+    ...envConfig,
+    ...filterUndefinedCliOptions(cliOptions),
+  };
+
+  configCache.set(cacheKey, config);
+  return config;
+}
+
+function filterUndefinedCliOptions(
+  options: CliConfigOptions,
+): Partial<MgrepConfig> {
+  const result: Partial<MgrepConfig> = {};
+  if (options.maxFileSize !== undefined) {
+    result.maxFileSize = options.maxFileSize;
+  }
+  return result;
+}
+
+/**
+ * Clears the configuration cache.
+ * Useful for testing or when config files may have changed.
+ */
+export function clearConfigCache(): void {
+  configCache.clear();
+}
+
+/**
+ * Checks if a file exceeds the maximum allowed file size
+ *
+ * @param filePath - The path to the file to check
+ * @param maxFileSize - The maximum allowed file size in bytes
+ * @returns True if the file exceeds the limit, false otherwise
+ */
+export function exceedsMaxFileSize(
+  filePath: string,
+  maxFileSize: number,
+): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.size > maxFileSize;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Formats a file size in bytes to a human-readable string
+ *
+ * @param bytes - The file size in bytes
+ * @returns Human-readable file size string
+ */
+export function formatFileSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${size.toFixed(unitIndex === 0 ? 0 : 2)} ${units[unitIndex]}`;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce configurable `maxFileSize` (via CLI/env/config) and skip oversized files during sync and watch; update docs and tests.
> 
> - **Config system**
>   - Add YAML config loader in `src/lib/config.ts` with precedence: CLI `--max-file-size` > `MGREP_MAX_FILE_SIZE` > local `.mgreprc.yaml/.yml` > global `~/.config/mgrep/config.yaml/.yml` > defaults.
>   - Provide helpers: `loadConfig`, `exceedsMaxFileSize`, `formatFileSize` and cache handling.
> - **CLI changes**
>   - Add `--max-file-size <bytes>` to `mgrep search` and `mgrep watch` with validation, plumbed via `loadConfig`.
>   - Watch options refactor: define `WatchOptions` interface.
> - **Sync/Upload behavior**
>   - Enforce max file size in `initialSync` and `uploadFile` to skip oversized files; pass `config` through `search`/`watch` flows.
> - **Docs**
>   - Update `README.md` with new flag, config file format, precedence, examples, and env var `MGREP_MAX_FILE_SIZE`.
> - **Dependencies**
>   - Add `yaml` to `package.json` and lockfile.
> - **Tests**
>   - Extend `test/test.bats` to cover YAML config, `.yml` support, CLI flag/env var precedence, and skipping large files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2abf0ca00f802e8d366d22c3a9a49ec8b8fb894. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->