### PR TITLE
chore: fix python 3.9 incompatibility

### DIFF
--- a/plugins/mgrep/hooks/mgrep_watch.py
+++ b/plugins/mgrep/hooks/mgrep_watch.py
@@ -8,7 +8,7 @@ from pathlib import Path
 DEBUG_LOG_FILE = Path(os.environ.get("MGREP_WATCH_LOG", "/tmp/mgrep-watch.log"))
 
 
-def debug_log(message: str) -> None:
+def debug_log(message: str):
     try:
         DEBUG_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -18,7 +18,7 @@ def debug_log(message: str) -> None:
         pass
 
 
-def read_hook_input() -> dict[str, object] | None:
+def read_hook_input():
     raw = sys.stdin.read()
     if not raw.strip():
         return None

--- a/plugins/mgrep/hooks/mgrep_watch_kill.py
+++ b/plugins/mgrep/hooks/mgrep_watch_kill.py
@@ -8,7 +8,7 @@ from pathlib import Path
 DEBUG_LOG_FILE = Path(os.environ.get("MGREP_WATCH_KILL_LOG", "/tmp/mgrep-watch-kill.log"))
 
 
-def debug_log(message: str) -> None:
+def debug_log(message: str):
     try:
         DEBUG_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -18,7 +18,7 @@ def debug_log(message: str) -> None:
         pass
 
 
-def read_hook_input() -> dict[str, object] | None:
+def read_hook_input():
     raw = sys.stdin.read()
     if not raw.strip():
         return None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove return and parameter type hints from `debug_log` and `read_hook_input` in mgrep hook scripts to restore Python 3.9 compatibility.
> 
> - **Hooks (Python 3.9 compatibility)**:
>   - `plugins/mgrep/hooks/mgrep_watch.py`:
>     - Remove type hints from `debug_log` and `read_hook_input`.
>   - `plugins/mgrep/hooks/mgrep_watch_kill.py`:
>     - Remove type hints from `debug_log` and `read_hook_input`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10df8ffa5b45a95ef033b103dfc4102e3d14e671. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->