### PR TITLE
chore: make mgrep backwards compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mixedbread/mgrep",
   "version": "0.1.7",
+  "type": "module",
   "author": "Mixedbread <support@mixedbread.com>",
   "homepage": "https://www.mixedbread.com/",
   "bugs": {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,9 +3,9 @@ import chalk from "chalk";
 import { Command } from "commander";
 import open from "open";
 import yoctoSpinner from "yocto-spinner";
-import { authClient } from "../lib/auth";
-import { selectOrganization } from "../lib/organizations";
-import { getStoredToken, pollForToken, storeToken } from "../lib/token";
+import { authClient } from "../lib/auth.js";
+import { selectOrganization } from "../lib/organizations.js";
+import { getStoredToken, pollForToken, storeToken } from "../lib/token.js";
 
 const CLIENT_ID = "mgrep";
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,7 +1,7 @@
 import { outro } from "@clack/prompts";
 import chalk from "chalk";
 import { Command } from "commander";
-import { deleteToken, getStoredToken } from "../lib/token";
+import { deleteToken, getStoredToken } from "../lib/token.js";
 
 export async function logoutAction() {
   const token = await getStoredToken();

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -5,21 +5,21 @@ import {
   type CliConfigOptions,
   loadConfig,
   type MgrepConfig,
-} from "../lib/config";
-import { createFileSystem, createStore } from "../lib/context";
-import { DEFAULT_IGNORE_PATTERNS } from "../lib/file";
+} from "../lib/config.js";
+import { createFileSystem, createStore } from "../lib/context.js";
+import { DEFAULT_IGNORE_PATTERNS } from "../lib/file.js";
 import type {
   AskResponse,
   ChunkType,
   FileMetadata,
   SearchResponse,
   Store,
-} from "../lib/store";
+} from "../lib/store.js";
 import {
   createIndexingSpinner,
   formatDryRunSummary,
-} from "../lib/sync-helpers";
-import { initialSync, QuotaExceededError } from "../lib/utils";
+} from "../lib/sync-helpers.js";
+import { initialSync, QuotaExceededError } from "../lib/utils.js";
 
 function extractSources(response: AskResponse): { [key: number]: ChunkType } {
   const sources: { [key: number]: ChunkType } = {};

--- a/src/commands/switch-org.ts
+++ b/src/commands/switch-org.ts
@@ -4,8 +4,8 @@ import { Command } from "commander";
 import {
   getCurrentOrganization,
   selectOrganization,
-} from "../lib/organizations";
-import { getStoredToken } from "../lib/token";
+} from "../lib/organizations.js";
+import { getStoredToken } from "../lib/token.js";
 
 export async function switchOrgAction() {
   intro(chalk.bold("🔄 Switch Organization"));

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,19 +1,19 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Command, InvalidArgumentError } from "commander";
-import { type CliConfigOptions, loadConfig } from "../lib/config";
-import { createFileSystem, createStore } from "../lib/context";
-import { DEFAULT_IGNORE_PATTERNS } from "../lib/file";
+import { type CliConfigOptions, loadConfig } from "../lib/config.js";
+import { createFileSystem, createStore } from "../lib/context.js";
+import { DEFAULT_IGNORE_PATTERNS } from "../lib/file.js";
 import {
   createIndexingSpinner,
   formatDryRunSummary,
-} from "../lib/sync-helpers";
+} from "../lib/sync-helpers.js";
 import {
   deleteFile,
   initialSync,
   QuotaExceededError,
   uploadFile,
-} from "../lib/utils";
+} from "../lib/utils.js";
 
 export interface WatchOptions {
   store: string;

--- a/src/commands/watch_mcp.ts
+++ b/src/commands/watch_mcp.ts
@@ -5,7 +5,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Command } from "commander";
-import { startWatch } from "./watch";
+import { startWatch } from "./watch.js";
 
 export const watchMcp = new Command("mcp")
   .description("Start MCP server for mgrep")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { program } from "commander";
-import { login } from "./commands/login";
-import { logout } from "./commands/logout";
-import { search } from "./commands/search";
-import { switchOrg } from "./commands/switch-org";
-import { watch } from "./commands/watch";
-import { watchMcp } from "./commands/watch_mcp";
-import { installClaudeCode, uninstallClaudeCode } from "./install/claude-code";
-import { installCodex, uninstallCodex } from "./install/codex";
-import { installDroid, uninstallDroid } from "./install/droid";
-import { installOpencode, uninstallOpencode } from "./install/opencode";
-import { setupLogger } from "./lib/logger";
+import { login } from "./commands/login.js";
+import { logout } from "./commands/logout.js";
+import { search } from "./commands/search.js";
+import { switchOrg } from "./commands/switch-org.js";
+import { watch } from "./commands/watch.js";
+import { watchMcp } from "./commands/watch_mcp.js";
+import {
+  installClaudeCode,
+  uninstallClaudeCode,
+} from "./install/claude-code.js";
+import { installCodex, uninstallCodex } from "./install/codex.js";
+import { installDroid, uninstallDroid } from "./install/droid.js";
+import { installOpencode, uninstallOpencode } from "./install/opencode.js";
+import { setupLogger } from "./lib/logger.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 setupLogger();
 

--- a/src/install/claude-code.ts
+++ b/src/install/claude-code.ts
@@ -1,7 +1,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { Command } from "commander";
-import { ensureAuthenticated } from "../lib/utils";
+import { ensureAuthenticated } from "../lib/utils.js";
 
 const shell =
   process.env.SHELL ||

--- a/src/install/codex.ts
+++ b/src/install/codex.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { Command } from "commander";
-import { ensureAuthenticated } from "../lib/utils";
+import { ensureAuthenticated } from "../lib/utils.js";
 
 const shell =
   process.env.SHELL ||

--- a/src/install/droid.ts
+++ b/src/install/droid.ts
@@ -1,8 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
-import { ensureAuthenticated } from "../lib/utils";
+import { ensureAuthenticated } from "../lib/utils.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const PLUGIN_ROOT =
   process.env.DROID_PLUGIN_ROOT ||

--- a/src/install/opencode.ts
+++ b/src/install/opencode.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
-import { ensureAuthenticated } from "../lib/utils";
+import { ensureAuthenticated } from "../lib/utils.js";
 
 const TOOL_PATH = path.join(
   os.homedir(),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,8 +3,8 @@ import {
   deviceAuthorizationClient,
   organizationClient,
 } from "better-auth/client/plugins";
-import { getStoredToken } from "./token";
-import { isDevelopment } from "./utils";
+import { getStoredToken } from "./token.js";
+import { isDevelopment } from "./utils.js";
 
 export const SERVER_URL = isDevelopment()
   ? "http://localhost:3001"

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,13 +1,13 @@
 import Mixedbread from "@mixedbread/sdk";
-import { getJWTToken } from "./auth";
+import { getJWTToken } from "./auth.js";
 import {
   type FileSystem,
   type FileSystemOptions,
   NodeFileSystem,
-} from "./file";
-import { type Git, NodeGit } from "./git";
-import { MixedbreadStore, type Store, TestStore } from "./store";
-import { ensureAuthenticated, isDevelopment, isTest } from "./utils";
+} from "./file.js";
+import { type Git, NodeGit } from "./git.js";
+import { MixedbreadStore, type Store, TestStore } from "./store.js";
+import { ensureAuthenticated, isDevelopment, isTest } from "./utils.js";
 
 const BASE_URL = isDevelopment()
   ? "http://localhost:8000"

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import ignore from "ignore";
-import type { Git } from "./git";
+import type { Git } from "./git.js";
 
 /**
  * Default glob patterns to ignore during file indexing.

--- a/src/lib/organizations.ts
+++ b/src/lib/organizations.ts
@@ -1,7 +1,7 @@
 import { cancel, isCancel, select } from "@clack/prompts";
 import type { Organization } from "better-auth/plugins/organization";
 import chalk from "chalk";
-import { authClient, SERVER_URL } from "./auth";
+import { authClient, SERVER_URL } from "./auth.js";
 
 export async function getCurrentOrganization(accessToken: string) {
   const { data: session } = await authClient.getSession({

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import chalk from "chalk";
 import yoctoSpinner from "yocto-spinner";
-import { type AuthClient, SERVER_URL } from "./auth";
+import { type AuthClient, SERVER_URL } from "./auth.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".mgrep");
 const TOKEN_FILE = path.join(CONFIG_DIR, "token.json");

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,13 +4,13 @@ import * as path from "node:path";
 import { cancel, confirm, isCancel } from "@clack/prompts";
 import { isText } from "istextorbinary";
 import pLimit from "p-limit";
-import { loginAction } from "../commands/login";
-import { exceedsMaxFileSize, type MgrepConfig } from "./config";
-import type { FileSystem } from "./file";
-import type { Store } from "./store";
-import type { InitialSyncProgress, InitialSyncResult } from "./sync-helpers";
+import { loginAction } from "../commands/login.js";
+import { exceedsMaxFileSize, type MgrepConfig } from "./config.js";
+import type { FileSystem } from "./file.js";
+import type { Store } from "./store.js";
+import type { InitialSyncProgress, InitialSyncResult } from "./sync-helpers.js";
 
-import { getStoredToken } from "./token";
+import { getStoredToken } from "./token.js";
 
 export const isTest = process.env.MGREP_IS_TEST === "1";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,12 +8,12 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "esModuleInterop": true,
-    "module": "CommonJS",
-    "target": "ES6",
+    "module": "NodeNext",
+    "target": "ES2022",
     "rootDir": "src",
     "incremental": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "moduleResolution": "node"
+    "moduleResolution": "NodeNext"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the project to native ESM with NodeNext resolution, updating imports to `.js`, adding ESM-safe `__dirname` handling, and adjusting build targets.
> 
> - **Build/Runtime**
>   - Set package to ESM by adding `"type": "module"` in `package.json`.
>   - Update TypeScript config to `"module": "NodeNext"`, `"moduleResolution": "NodeNext"`, and `"target": "ES2022"`.
> - **Codebase**
>   - Convert internal imports to ESM paths with `.js` extensions across `src/**` (commands, install, lib).
>   - Add ESM-compatible `__filename`/`__dirname` via `fileURLToPath` in `src/index.ts` and `src/install/droid.ts`.
>   - Ensure CLI entry reads version via ESM path logic and updates command registrations.
>   - Minor MCP/watch import alignment (`watch_mcp` -> `./watch.js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff4b973b2cdc302d0a879f0b4634b751eb3f8741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->