### PR TITLE
chore: test correct folder upload behavior with prefixes

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -388,3 +388,24 @@ teardown() {
     assert_success
     assert_output --partial 'test.txt'
 }
+
+@test "Sync from folder does not include files from folder with same prefix" {
+    mkdir -p "$BATS_TMPDIR/test-store/foo"
+    mkdir -p "$BATS_TMPDIR/test-store/foobar"
+    echo "File in foo" > "$BATS_TMPDIR/test-store/foo/file-in-foo.txt"
+    echo "File in foobar" > "$BATS_TMPDIR/test-store/foobar/file-in-foobar.txt"
+
+    cd "$BATS_TMPDIR/test-store/foobar"
+    run mgrep watch --dry-run
+
+    assert_success
+    assert_output --partial 'file-in-foobar.txt'
+    refute_output --partial 'file-in-foo.txt'
+
+    cd "$BATS_TMPDIR/test-store/foo"
+    run mgrep watch --dry-run
+
+    assert_success
+    assert_output --partial 'file-in-foo.txt'
+    refute_output --partial 'file-in-foobar.txt'
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Bats test verifying `mgrep watch --dry-run` only processes files in the exact current directory (`foo` vs `foobar`) and doesn’t include similarly-prefixed sibling folders.
> 
> - **Tests**:
>   - Add Bats test in `test/test.bats` ensuring `mgrep watch --dry-run` syncs only files from the exact current folder and excludes files from a sibling directory with the same prefix (e.g., `foo` vs `foobar`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb66995e5b2d8b19fa3801ec7df001a5ebdf5848. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->