### PR TITLE
chore: update the npm token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,13 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
@@ -63,7 +64,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update release workflow to use OIDC with workflow-level permissions and bump Node to 24, removing the need for NPM_TOKEN.
> 
> - **CI/Release workflow (`.github/workflows/release.yml`)**:
>   - Switch to OIDC: move permissions to workflow-level (`permissions: id-token: write, contents: read`) and drop job-level permissions and `NODE_AUTH_TOKEN` env for `npm publish`.
>   - Bump Node version in `actions/setup-node` from `20` to `24`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9183549f8a7fdc60b4733c6a2f4ced89407be090. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->