### PR TITLE
fix: add Windows compatibility to hook scripts

### DIFF
--- a/plugins/mgrep/hooks/mgrep_watch_kill.py
+++ b/plugins/mgrep/hooks/mgrep_watch_kill.py
@@ -2,10 +2,12 @@ import os
 import signal
 import sys
 import json
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
-DEBUG_LOG_FILE = Path(os.environ.get("MGREP_WATCH_KILL_LOG", "/tmp/mgrep-watch-kill.log"))
+TEMP_DIR = Path(tempfile.gettempdir())
+DEBUG_LOG_FILE = Path(os.environ.get("MGREP_WATCH_KILL_LOG", str(TEMP_DIR / "mgrep-watch-kill.log")))
 
 
 def debug_log(message: str):
@@ -29,19 +31,55 @@ def read_hook_input():
         return None
 
 
+def kill_process(pid: int):
+    """Kill a process in a cross-platform way."""
+    try:
+        if sys.platform == "win32":
+            import subprocess
+            subprocess.run(
+                ["taskkill", "/F", "/PID", str(pid)],
+                capture_output=True,
+                check=False
+            )
+        else:
+            os.kill(pid, signal.SIGKILL)
+        return True
+    except (OSError, ProcessLookupError) as e:
+        debug_log(f"Failed to kill process {pid}: {e}")
+        return False
+
 
 if __name__ == "__main__":
     debug_log("Killing mgrep watch process")
     payload = read_hook_input()
 
-    pid_file = f"/tmp/mgrep-watch-pid-{payload.get('session_id')}.txt"
-    if not os.path.exists(pid_file):
-        debug_log(f"PID file not found: {pid_file}")
+    if not payload:
+        debug_log("No payload received")
         sys.exit(1)
-    pid = int(open(pid_file).read().strip())
-    debug_log(f"Killing mgrep watch process: {pid}")
-    os.kill(pid, signal.SIGKILL)
-    debug_log(f"Killed mgrep watch process: {pid}")
-    os.remove(pid_file)
-    debug_log(f"Removed PID file: {pid_file}")
+
+    session_id = payload.get("session_id", "unknown")
+    pid_file = TEMP_DIR / f"mgrep-watch-pid-{session_id}.txt"
+
+    if not pid_file.exists():
+        debug_log(f"PID file not found: {pid_file}")
+        sys.exit(0)
+
+    try:
+        pid = int(pid_file.read_text().strip())
+        debug_log(f"Killing mgrep watch process: {pid}")
+
+        if kill_process(pid):
+            debug_log(f"Killed mgrep watch process: {pid}")
+        else:
+            debug_log(f"Process {pid} may already be dead")
+
+    except (ValueError, OSError) as e:
+        debug_log(f"Error reading or killing process: {e}")
+
+    try:
+        pid_file.unlink()
+        debug_log(f"Removed PID file: {pid_file}")
+    except OSError as e:
+        debug_log(f"Failed to remove PID file: {e}")
+
     sys.exit(0)


### PR DESCRIPTION
Fixes #109

The hook scripts fail on Windows due to Unix-specific APIs:
- `os.setsid` doesn't exist on Windows
- `signal.SIGKILL` doesn't exist on Windows
- Hardcoded `/tmp/` paths don't exist on Windows
- `subprocess.Popen` can't find `.cmd` files without `shell=True`

Changes:
- Use `tempfile.gettempdir()` for cross-platform temp paths
- Add `find_mgrep_executable()` to locate mgrep.cmd on Windows
- Use `shell=True` + `CREATE_NEW_PROCESS_GROUP` on Windows
- Use `taskkill` instead of `SIGKILL` on Windows
- Add graceful error handling

Tested on Windows 11 with Python 3.14 and mgrep 0.1.6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Windows support and hardens the `mgrep` hook flow.
> 
> - Use `tempfile.gettempdir()` for PID/log files; replace hardcoded `/tmp/*`
> - New `find_mgrep_executable()` resolves `mgrep`/`mgrep.cmd` (including `%APPDATA%\npm`)
> - Windows-specific spawn: `shell=True` with `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`; Unix uses `preexec_fn=os.setsid`
> - Cross-platform termination: `taskkill /F /PID` on Windows; `SIGKILL` on Unix
> - Better resilience: handle missing payloads, skip when `mgrep` not found, avoid duplicate sessions via PID file, structured hook response always printed, expanded debug logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dd1dbd669a5fb983f66e431e937c6dacb07de25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->