### PR TITLE
chore: notify the user about mgreps background activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ mgrep "where do we set up auth?"
 
 ## Using it with Coding Agents
 
+> [!CAUTION]
+> **Background Sync Enabled**: When installed with a coding agent, mgrep runs a
+> background process that syncs your files to enable semantic search. This
+> process starts automatically when you begin a session and stops when your
+> session ends. You can see your current usage in the [Mixedbread
+> platform](https://www.platform.mixedbread.com/).
+
 `mgrep` supports assisted installation commands for many agents:
 - `mgrep install-claude-code` for Claude Code
 - `mgrep install-opencode` for OpenCode

--- a/src/install/claude-code.ts
+++ b/src/install/claude-code.ts
@@ -2,6 +2,7 @@ import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { Command } from "commander";
 import { ensureAuthenticated } from "../lib/utils.js";
+import { printInstallWarning } from "../lib/warning.js";
 
 const shell =
   process.env.SHELL ||
@@ -38,6 +39,8 @@ async function installPlugin() {
     );
     process.exit(1);
   }
+
+  printInstallWarning("Claude Code", "mgrep uninstall-claude-code");
 }
 
 async function uninstallPlugin() {

--- a/src/install/codex.ts
+++ b/src/install/codex.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { Command } from "commander";
 import { ensureAuthenticated } from "../lib/utils.js";
+import { printInstallWarning } from "../lib/warning.js";
 
 const shell =
   process.env.SHELL ||
@@ -76,6 +77,8 @@ async function installPlugin() {
     } else {
       console.log("The mgrep skill is already installed in the Codex agent");
     }
+
+    printInstallWarning("Codex", "mgrep uninstall-codex");
   } catch (error) {
     console.error(`Error installing plugin: ${error}`);
     process.exit(1);

--- a/src/install/droid.ts
+++ b/src/install/droid.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { ensureAuthenticated } from "../lib/utils.js";
+import { printInstallWarning } from "../lib/warning.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -187,6 +188,8 @@ async function installPlugin() {
   console.log(
     `Installed the mgrep hooks and skill for Factory Droid in ${root}`,
   );
+
+  printInstallWarning("Factory Droid", "mgrep uninstall-droid");
 }
 
 async function uninstallPlugin() {

--- a/src/install/opencode.ts
+++ b/src/install/opencode.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { ensureAuthenticated } from "../lib/utils.js";
+import { printInstallWarning } from "../lib/warning.js";
 
 const TOOL_PATH = path.join(
   os.homedir(),
@@ -103,6 +104,8 @@ async function installPlugin() {
     };
     fs.writeFileSync(MCP_PATH, JSON.stringify(mcpJson, null, 2));
     console.log("Successfully installed the mgrep tool in the OpenCode agent");
+
+    printInstallWarning("OpenCode", "mgrep uninstall-opencode");
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`Error installing tool: ${errorMessage}`);

--- a/src/lib/warning.ts
+++ b/src/lib/warning.ts
@@ -1,0 +1,47 @@
+import chalk from "chalk";
+
+/**
+ * Prints a prominent warning message about mgrep's background sync behavior.
+ * Should be called after successful installation to inform users.
+ * @param agentName - The name of the agent mgrep was installed for (e.g., "Claude Code", "OpenCode")
+ * @param uninstallCommand - The command to run to uninstall mgrep from this agent
+ */
+export function printInstallWarning(
+  agentName: string,
+  uninstallCommand: string,
+): void {
+  const border = chalk.yellow("═".repeat(70));
+  const warningIcon = chalk.yellow.bold("⚠️  WARNING");
+
+  console.log();
+  console.log(border);
+  console.log();
+  console.log(`  ${warningIcon}`);
+  console.log();
+  console.log(chalk.yellow.bold("  BACKGROUND SYNC ENABLED"));
+  console.log();
+  console.log(
+    chalk.white(
+      "  mgrep runs a background process that syncs your files to enable",
+    ),
+  );
+  console.log(chalk.white("  semantic search. This process:"));
+  console.log();
+  console.log(
+    chalk.white("    • Starts automatically when you begin a session"),
+  );
+  console.log(chalk.white("    • Indexes files in your working directory"));
+  console.log(
+    chalk.white(
+      "    • Syncs file content to mixedbread's servers for embedding (this creates usage on the mixedbread platform)",
+    ),
+  );
+  console.log(chalk.white("    • Stops when your session ends"));
+  console.log();
+  console.log(chalk.cyan.bold(`  To uninstall mgrep from ${agentName}:`));
+  console.log();
+  console.log(chalk.green(`    ${uninstallCommand}`));
+  console.log();
+  console.log(border);
+  console.log();
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Highlights mgrep’s background sync behavior during agent installs and in documentation.
> 
> - New `printInstallWarning` in `src/lib/warning.ts` to display a detailed background-sync notice with uninstall instructions
> - Called after successful installs in `install-claude-code`, `install-opencode`, `install-codex`, and `install-droid`
> - README: adds a CAUTION section explaining background sync during coding agent sessions and directs users to view usage on the Mixedbread platform
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cff0b79542d386b211afcd4866cfd17aa82df42a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->