### PR TITLE
perf(sync): use mtime to skip unchanged files during sync.

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -12,6 +12,7 @@ import type {
 export interface FileMetadata {
   path: string;
   hash: string;
+  mtime?: number;
 }
 
 export type ChunkType =


### PR DESCRIPTION

  Summary

  - Use file mtime as a bloom filter to skip unnecessary file reads during sync
  - Only compute hash when mtime has changed, avoiding redundant I/O operations

  Motivation

  Current sync reads every file and computes hash to detect changes. For a repo with 1000 files where only 10 changed, it still reads all 1000 files.

  mtime property: If file content changed, mtime must change (no false negatives). This makes it a perfect first-pass filter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces mtime-based short-circuiting in sync to avoid reading and hashing unchanged files.
> 
> - Add `mtime` to `FileMetadata`; upload now records `metadata.mtime` from `fs.stat`
> - Replace `listStoreFileHashes` with `listStoreFileMetadata` returning `{ hash, mtime }`
> - `initialSync` uses stored `mtime` as a bloom filter; only reads file and verifies hash when mtime changed or missing
> - Minor refactor: parallel `readFile` + `stat` in `uploadFile`; progress/deletion logic unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b87dc7e16add8116d75964c63e69320e053caa6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->