### PR TITLE
docs: add file/folder limits info and fix incorrect defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ mgrep can be configured via config files, environment variables, or CLI flags.
 Create a `.mgreprc.yaml` (or `.mgreprc.yml`) in your project root for local configuration, or `~/.config/mgrep/config.yaml` (or `config.yml`) for global configuration.
 
 ```yaml
-# Maximum file size in bytes to upload (default: 10MB)
+# Maximum file size in bytes to upload (default: 1MB)
 maxFileSize: 5242880
 
-# Maximum number of files to upload (default: 10000)
+# Maximum number of files to upload (default: 1000)
 maxFileCount: 5000
 ```
 
@@ -287,8 +287,8 @@ searches.
 
 ### Sync Options
 
-- `MGREP_MAX_FILE_SIZE`: Maximum file size in bytes to upload (default: `10485760` / 10MB)
-- `MGREP_MAX_FILE_COUNT`: Maximum number of files to upload (default: `10000`)
+- `MGREP_MAX_FILE_SIZE`: Maximum file size in bytes to upload (default: `1048576` / 1MB)
+- `MGREP_MAX_FILE_COUNT`: Maximum number of files to upload (default: `1000`)
 
 **Examples:**
 ```bash

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,14 +31,14 @@ export interface MgrepConfig {
   /**
    * Maximum file size in bytes that is allowed to upload.
    * Files larger than this will be skipped during sync.
-   * @default 10485760 (10 MB)
+   * @default 1048576 (1 MB)
    */
   maxFileSize: number;
 
   /**
    * Maximum number of files that can be uploaded in a single sync operation.
    * If the folder contains more files than this limit, an error will be thrown.
-   * @default 10000
+   * @default 1000
    */
   maxFileCount: number;
 }


### PR DESCRIPTION
Include the file size and folder limits in the README as information block when explaining the usage with agents in the beginning. Also include a small example on how to manually watch a folder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs to clarify default sync limits and how to control them.
> 
> - Adds a NOTE block in `README.md` stating default limits (`1MB` per file, `1000` files per directory) and how to customize via CLI/env/config; includes a manual `mgrep watch /path/to/your/project` example
> - Updates Configuration and Environment Variables sections to reflect new defaults (`MGREP_MAX_FILE_SIZE=1048576`, `MGREP_MAX_FILE_COUNT=1000`) and adjusts sample YAML comments
> - Aligns `src/lib/config.ts` JSDoc default values to `1MB` and `1000` to match runtime defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc90486ec8eebdc772ecd873cf50bfe1f1d2108a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->