### PR TITLE
fix: handle ProcessLookupError in session cleanup hook

### DIFF
--- a/plugins/mgrep/hooks/mgrep_watch_kill.py
+++ b/plugins/mgrep/hooks/mgrep_watch_kill.py
@@ -40,8 +40,11 @@ if __name__ == "__main__":
         sys.exit(1)
     pid = int(open(pid_file).read().strip())
     debug_log(f"Killing mgrep watch process: {pid}")
-    os.kill(pid, signal.SIGKILL)
-    debug_log(f"Killed mgrep watch process: {pid}")
+    try:
+        os.kill(pid, signal.SIGKILL)
+        debug_log(f"Killed mgrep watch process: {pid}")
+    except ProcessLookupError:
+        debug_log(f"Process {pid} already exited")
     os.remove(pid_file)
     debug_log(f"Removed PID file: {pid_file}")
     sys.exit(0)


### PR DESCRIPTION
## Summary

- Handle race condition where watcher process exits before cleanup hook runs

## Problem

When a Claude Code session ends, `mgrep_watch_kill.py` tries to kill the watcher process. If the process has already exited naturally, `os.kill()` raises `ProcessLookupError`, causing the hook to fail with a visible error message.
<img width="1918" height="424" alt="CleanShot 2026-01-18 at 16 01 55@2x" src="https://github.com/user-attachments/assets/a5967e1f-0db8-4a83-ba05-8148549a6f66" />

## Fix

Wrap the `os.kill()` call in a try/except to gracefully handle the case where the process no longer exists.

## Test plan

- [ ] End a Claude Code session and confirm no error appears
- [ ] Verify watcher process is still killed when it exists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handles race where the watcher process may already have exited before cleanup runs.
> 
> - Wraps `os.kill(pid, SIGKILL)` in a `try/except ProcessLookupError` in `plugins/mgrep/hooks/mgrep_watch_kill.py` to avoid failing when the process no longer exists
> - Adds a debug log when the process has already exited; still removes the PID file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cb8a26f17ecd78946ea6beb8a7c647c9410c10b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->