### PR TITLE
fix: filter out deleted orgs in org select

### DIFF
--- a/src/lib/organizations.ts
+++ b/src/lib/organizations.ts
@@ -24,9 +24,10 @@ export async function listOrganizations(accessToken: string) {
     },
   });
 
-  const organizations: Array<Organization> = await response.json();
+  const organizations: Array<Organization & { deletedAt?: string }> =
+    await response.json();
 
-  return organizations;
+  return organizations.filter((org) => !org.deletedAt);
 }
 
 export async function selectOrganization(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized client-side filtering change; risk is limited to potentially hiding orgs if the API sets `deletedAt` unexpectedly.
> 
> **Overview**
> Updates `listOrganizations` to treat the API response as possibly including a `deletedAt` field and **filters out any organizations with `deletedAt` set** before returning results, preventing deleted orgs from showing up in the organization selection flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 630bbbff0aecf8be0e71961aee5a45255f7b29d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->