### PR TITLE
fix: pass project cwd to mgrep watch subprocess

### DIFF
--- a/plugins/mgrep/hooks/mgrep_watch.py
+++ b/plugins/mgrep/hooks/mgrep_watch.py
@@ -39,9 +39,10 @@ if __name__ == "__main__":
         debug_log(f"PID file already exists: {pid_file}")
         sys.exit(1)
 
-    process = subprocess.Popen(["mgrep", "watch"], preexec_fn=os.setsid, stdout=open(f"/tmp/mgrep-watch-command-{payload.get('session_id')}.log", "w"), stderr=open(f"/tmp/mgrep-watch-command-{payload.get('session_id')}.log", "w"))
+    debug_log(f"Starting mgrep watch in cwd: {cwd}")
+    log_file = open(f"/tmp/mgrep-watch-command-{payload.get('session_id')}.log", "w")
+    process = subprocess.Popen(["mgrep", "watch"], cwd=cwd, preexec_fn=os.setsid, stdout=log_file, stderr=log_file)
     debug_log(f"Started mgrep watch process: {process.pid}")
-    debug_log(f"All environment variables: {os.environ}")
     with open(pid_file, "w") as handle:
         handle.write(str(process.pid))
 


### PR DESCRIPTION
## Problem

When Claude Code starts a session, the SessionStart hook launches `mgrep watch` as a background process. The hook reads `cwd` from the hook payload — the project directory Claude was opened in — but never passes it to `subprocess.Popen`. The watcher inherits the working directory of the hook runner instead, which is typically the home directory. It immediately hits the home-directory guard and exits with "Cannot watch home directory or any parent directory." The watcher never starts, and because the failure is silent, it looks like mgrep simply is not indexing anything.

## Root cause

In `mgrep_watch.py`, `payload.get("cwd")` is called and assigned to `cwd`, but that value is never used. The `subprocess.Popen` call has no `cwd` argument, so Python falls back to `os.getcwd()` at the time the hook runs — not the project directory.

## Fix

Pass `cwd=cwd` to `subprocess.Popen`. One argument, no other behaviour changes.

I also removed the `debug_log(f"All environment variables: {os.environ}")` line. It was writing the full process environment to a file under `/tmp` on every session start. That includes anything sensitive in the environment — API keys, tokens, whatever the user has set. It is not something that should be sitting in a world-readable temp directory, and it was not adding anything useful once the actual bug was fixed.

## Testing

Tested on macOS 15 with Claude Code and the mgrep plugin installed. Before the fix, every session start produced the home-directory error in the watcher log. After the fix, the watcher starts in the correct project directory and the initial sync completes. Verified against a project with 223 files — all indexed cleanly on first run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the SessionStart hook: it only adjusts the working directory used to launch `mgrep watch` and removes overly-verbose/sensitive debug logging.
> 
> **Overview**
> Fixes `mgrep watch` startup by launching the watcher subprocess with `cwd` from the hook payload so it runs in the project directory instead of the hook runner’s default directory.
> 
> Also tightens logging by writing watcher stdout/stderr to a single per-session log file and removing the debug line that dumped all environment variables to disk under `/tmp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f22366732a8a873d06ddb8b6c7c74d9904ee3be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->