### PR TITLE
fix(watch): skip ignored directories when watching

### DIFF
--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -139,44 +139,157 @@ export async function startWatch(options: WatchOptions): Promise<void> {
 
     console.log("Watching for file changes in", watchRoot);
     fileSystem.loadMgrepignore(watchRoot);
-    fs.watch(watchRoot, { recursive: true }, (eventType, rawFilename) => {
-      const filename = rawFilename?.toString();
-      if (!filename) {
+
+    // Use per-directory non-recursive watchers to avoid watching ignored
+    // directories like .git/, node_modules/, target/, etc. fs.watch with
+    // recursive: true allocates inotify watches on ALL subdirectories before
+    // the callback filter runs, which exhausts the kernel watcher limit on
+    // large repos.
+    const watchers = new Map<string, fs.FSWatcher>();
+
+    function isMissingPathError(error: unknown): boolean {
+      return (
+        error instanceof Error &&
+        "code" in error &&
+        (error.code === "ENOENT" || error.code === "ENOTDIR")
+      );
+    }
+
+    function getPathStats(filePath: string): fs.Stats | null | undefined {
+      try {
+        return fs.statSync(filePath);
+      } catch (error) {
+        if (isMissingPathError(error)) {
+          return null;
+        }
+
+        console.warn(`Warning: failed to inspect path ${filePath}:`, error);
+        return undefined;
+      }
+    }
+
+    function closeWatcher(dirPath: string): void {
+      const watcher = watchers.get(dirPath);
+      if (!watcher) {
         return;
       }
-      const filePath = path.join(watchRoot, filename);
+
+      watcher.close();
+      watchers.delete(dirPath);
+    }
+
+    function closeWatcherSubtree(dirPath: string): void {
+      const prefix = `${dirPath}${path.sep}`;
+
+      for (const watchedPath of Array.from(watchers.keys())) {
+        if (watchedPath === dirPath || watchedPath.startsWith(prefix)) {
+          closeWatcher(watchedPath);
+        }
+      }
+    }
+
+    function handleDeletion(filePath: string): void {
+      closeWatcherSubtree(filePath);
+
+      void deleteFile(store, options.store, filePath)
+        .then(() => {
+          console.log(`delete: ${filePath}`);
+        })
+        .catch((error) => {
+          console.error("Failed to delete file:", filePath, error);
+        });
+    }
+
+    function handleFileEvent(
+      eventType: fs.WatchEventType,
+      dirPath: string,
+      name: string,
+    ): void {
+      const filePath = path.join(dirPath, name);
 
       if (fileSystem.isIgnored(filePath, watchRoot)) {
         return;
       }
 
-      try {
-        const stat = fs.statSync(filePath);
-        if (!stat.isFile()) {
-          return;
-        }
-
-        uploadFile(store, options.store, filePath, filename, config)
-          .then((didUpload) => {
-            if (didUpload) {
-              console.log(`${eventType}: ${filePath}`);
-            }
-          })
-          .catch((err) => {
-            console.error("Failed to upload changed file:", filePath, err);
-          });
-      } catch {
-        if (filePath.startsWith(watchRoot) && !fs.existsSync(filePath)) {
-          deleteFile(store, options.store, filePath)
-            .then(() => {
-              console.log(`delete: ${filePath}`);
-            })
-            .catch((err) => {
-              console.error("Failed to delete file:", filePath, err);
-            });
-        }
+      const stats = getPathStats(filePath);
+      if (stats === undefined) {
+        return;
       }
-    });
+
+      if (stats === null) {
+        handleDeletion(filePath);
+        return;
+      }
+
+      if (stats.isDirectory()) {
+        watchDirectory(filePath);
+        return;
+      }
+
+      if (!stats.isFile()) {
+        return;
+      }
+
+      void uploadFile(
+        store,
+        options.store,
+        filePath,
+        path.basename(filePath),
+        config,
+      )
+        .then((didUpload) => {
+          if (didUpload) {
+            console.log(`${eventType}: ${filePath}`);
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to upload changed file:", filePath, error);
+        });
+    }
+
+    function watchDirectory(dirPath: string): void {
+      if (watchers.has(dirPath)) {
+        return;
+      }
+
+      if (dirPath !== watchRoot && fileSystem.isIgnored(dirPath, watchRoot)) {
+        return;
+      }
+
+      const stats = getPathStats(dirPath);
+      if (!stats?.isDirectory()) {
+        return;
+      }
+
+      try {
+        const watcher = fs.watch(dirPath, (eventType, rawFilename) => {
+          const name = rawFilename?.toString();
+          if (!name) {
+            return;
+          }
+
+          handleFileEvent(eventType, dirPath, name);
+        });
+        watchers.set(dirPath, watcher);
+      } catch (error) {
+        console.warn(`Warning: failed to watch ${dirPath}:`, error);
+        return;
+      }
+
+      try {
+        for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+          if (!entry.isDirectory()) {
+            continue;
+          }
+
+          watchDirectory(path.join(dirPath, entry.name));
+        }
+      } catch (error) {
+        console.warn(`Warning: failed to read directory ${dirPath}:`, error);
+      }
+    }
+
+    watchDirectory(watchRoot);
   } catch (error) {
     if (refreshInterval) {
       clearInterval(refreshInterval);


### PR DESCRIPTION
## Summary
- replace recursive `fs.watch` with per-directory non-recursive watchers
- skip ignored directories before allocating watchers, including `.git/`, hidden paths, and ignore-pattern matches
- add subtree watcher cleanup when directories disappear and keep upload/delete handling intact

## Testing
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome lint src/commands/watch.ts`
- `pnpm test` *(fails on existing unrelated test: `Config maxFileCount via YAML`)*

## Notes
- `pnpm lint` currently fails in this repo because the script runs `biome lint --check .`, and this installed Biome version rejects `--check` for `lint`.
- the watcher fix is isolated to `src/commands/watch.ts`; the failing dry-run config test exits before live watcher setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites the file watching mechanism that drives incremental upload/delete behavior, and platform-specific `fs.watch` edge cases could cause missed events or orphaned watchers.
> 
> **Overview**
> Replaces the single recursive `fs.watch` watcher with **per-directory, non-recursive watchers** that are created only for non-ignored paths, preventing inotify exhaustion on large repos (e.g., skipping `.git/`, `node_modules/`, and ignore-pattern matches).
> 
> Adds watcher lifecycle management: dynamically starts watching newly discovered directories, and **closes watchers for deleted directories/subtrees** while keeping existing upload-on-change and delete-on-missing behavior intact (now with safer stat/error handling and warning logs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ca07982e19e52ba5989619b15ccfadb7d8da47f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->